### PR TITLE
Fix compatibility issue with ZoneTree

### DIFF
--- a/src/Src/YATsDb.Lite/Infrastructure/Workers/ZoneTreeMaintainerHostedService.cs
+++ b/src/Src/YATsDb.Lite/Infrastructure/Workers/ZoneTreeMaintainerHostedService.cs
@@ -15,15 +15,14 @@ public sealed class ZoneTreeMaintainerHostedService<TKey, TValue> : IHostedServi
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        this.zoneTreeMaintainer.EnablePeriodicTimer = true;
+        this.zoneTreeMaintainer.EnableJobForCleaningInactiveCaches = true;
         return Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        this.zoneTreeMaintainer.EnablePeriodicTimer = false;
-        this.zoneTreeMaintainer.CompleteRunningTasks();
-        return Task.CompletedTask;
+        this.zoneTreeMaintainer.EnableJobForCleaningInactiveCaches = false;
+        return this.zoneTreeMaintainer.WaitForBackgroundThreadsAsync();
     }
 
     public void Dispose()

--- a/src/Src/YATsDb.Lite/Program.cs
+++ b/src/Src/YATsDb.Lite/Program.cs
@@ -34,7 +34,7 @@ public static class Program
         builder.Services.AddTransient<YATsDb.Core.HighLevel.IYatsdbHighLevelStorage, YATsDb.Core.HighLevel.YatsdbHighLevelStorage>();
         builder.Services.AddTransient<YATsDb.Core.LowLevel.IYatsdbLowLevelStorage, YATsDb.Core.LowLevel.YatsdbLowLevelStorage>();
         builder.Services.AddTransient<YATsDb.Core.LowLevel.IKvStorage, YATsDb.Core.LowLevel.KvStorage>();
-        builder.Services.AddSingleton<IZoneTree<byte[], byte[]>>(sp =>
+        builder.Services.AddSingleton<IZoneTree<Memory<byte>, Memory<byte>>>(sp =>
         {
             Services.Configuration.DbSetup dbSetup = sp.GetRequiredService<IOptions<Services.Configuration.DbSetup>>().Value;
 
@@ -53,7 +53,7 @@ public static class Program
             });
         });
 
-        builder.Services.AddHostedService<Infrastructure.Workers.ZoneTreeMaintainerHostedService<byte[], byte[]>>();
+        builder.Services.AddHostedService<Infrastructure.Workers.ZoneTreeMaintainerHostedService<Memory<byte>, Memory<byte>>>();
         builder.Services.AddTransient<YATsDb.Core.Services.ICache, YATsDb.Lite.Services.Implementation.YatsdbCache>();
 
 

--- a/src/Src/YATsDb/Infrastructure/Workers/ZoneTreeMaintainerHostedService.cs
+++ b/src/Src/YATsDb/Infrastructure/Workers/ZoneTreeMaintainerHostedService.cs
@@ -15,15 +15,14 @@ public sealed class ZoneTreeMaintainerHostedService<TKey, TValue> : IHostedServi
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        this.zoneTreeMaintainer.EnablePeriodicTimer = true;
+        this.zoneTreeMaintainer.EnableJobForCleaningInactiveCaches = true;
         return Task.CompletedTask;
     }
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        this.zoneTreeMaintainer.EnablePeriodicTimer = false;
-        this.zoneTreeMaintainer.CompleteRunningTasks();
-        return Task.CompletedTask;
+        this.zoneTreeMaintainer.EnableJobForCleaningInactiveCaches = false;
+        return this.zoneTreeMaintainer.WaitForBackgroundThreadsAsync();
     }
 
     public void Dispose()

--- a/src/Src/YATsDb/Program.cs
+++ b/src/Src/YATsDb/Program.cs
@@ -50,7 +50,7 @@ public class Program
         builder.Services.AddTransient< YATsDb.Core.HighLevel.IYatsdbHighLevelStorage, YATsDb.Core.HighLevel.YatsdbHighLevelStorage> ();
         builder.Services.AddTransient< YATsDb.Core.LowLevel.IYatsdbLowLevelStorage, YATsDb.Core.LowLevel.YatsdbLowLevelStorage > ();
         builder.Services.AddTransient<YATsDb.Core.LowLevel.IKvStorage, YATsDb.Core.LowLevel.KvStorage>();
-        builder.Services.AddSingleton<IZoneTree<byte[], byte[]>>(sp =>
+        builder.Services.AddSingleton<IZoneTree<Memory<byte>, Memory<byte>>>(sp =>
         {
             Services.Configuration.DbSetup dbSetup = sp.GetRequiredService<IOptions<Services.Configuration.DbSetup>>().Value;
 
@@ -69,7 +69,7 @@ public class Program
             });
         });
 
-        builder.Services.AddHostedService<Infrastructure.Workers.ZoneTreeMaintainerHostedService<byte[], byte[]>>();
+        builder.Services.AddHostedService<Infrastructure.Workers.ZoneTreeMaintainerHostedService<Memory<byte>, Memory<byte>>>();
         builder.Services.AddTransient<YATsDb.Core.Services.ICache, YATsDb.Services.Implementation.YatsdbCache>();
 
         builder.Services.AddNCronJob(cfg =>


### PR DESCRIPTION
Hello, Harrison314!

After some upgrade of ZoneTree package, your code no longer compiles. Here's a fix for the API and its AOT version.

1. The https://github.com/koculu/ZoneTree/discussions/53 suggests using the `EnableJobForCleaningInactiveCaches` property.
2. Method `CompleteRunningTasks` has been replaced with `WaitForBackgroundThreadsAsync` ([here's a link](https://github.com/koculu/ZoneTree/commit/b085602b69384a4398d134fac953cdd6ff148283#diff-59c1d32272320c277dd3e1af3f64b5da17620e0c73bac65f4f115d663b62cc20L71))

Not sure if the Lite code should also be changed manually, let me know if I need to change it.

Thanks in advance!